### PR TITLE
Fix minor bug in state-machines example.

### DIFF
--- a/examples/state-machines/state-machines.scm
+++ b/examples/state-machines/state-machines.scm
@@ -150,7 +150,7 @@
         (identifier-list? #'(final ...))
         (identifier-list? #'(source ...))
         (identifier-list? #'(target ...))
-        (not (null? #'(final ...))))
+        (not (null? (syntax->datum #'(final ...)))))
        (with-syntax
            (((state ...)
              (let loop ((input #'(initial final ... source ... target ...))


### PR DESCRIPTION
Convert final-states syntax object to a datum before checking if the
list of final states is non-empty.